### PR TITLE
axebomber.util/in-box fails to determine when the column of cell is 0.

### DIFF
--- a/src/axebomber/util.clj
+++ b/src/axebomber/util.clj
@@ -84,7 +84,7 @@
                     (if (border? (get-cell sheet cx cy) direction)
                       [cx cy]
                       (when (and
-                             (< 0 cx (dec (.. sheet (getRow cy) (getLastCellNum))))
+                             (< -1 cx (dec (.. sheet (getRow cy) (getLastCellNum))))
                              (< 0 cy (inc (.. sheet (getLastRowNum)))))
                         (recur (case direction :left (dec cx) :right (inc cx) cx)
                                (case direction :top (dec cy) :bottom (inc cy) cy))))))]

--- a/test/axebomber/complex_test.clj
+++ b/test/axebomber/complex_test.clj
@@ -8,7 +8,7 @@
            [java.util Date]))
 
 (defn template [sheet model]
-  (render sheet {:x 1 :y 1}
+  (render sheet {:x 0 :y 1}
           [:table
            [:tr
             [:td.header {:data-width 28} "営業日報"]]


### PR DESCRIPTION
When the column of `cell` is 0 and the upper cell has rowspan>1 (or colspan>1), `border?`returns `nil` and `when` condition is not satisfied. So `in-box` fails to determine top (or right).

But I'm not sure whether this PR fixes problems correctly.

これでも英語頑張ったんですが。。。
